### PR TITLE
Remote server discovery

### DIFF
--- a/android/.idea/deploymentTargetDropDown.xml
+++ b/android/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <value>
+      <entry key="app">
+        <State />
+      </entry>
+    </value>
+  </component>
+</project>

--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -4,15 +4,15 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/android/.idea/migrations.xml
+++ b/android/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -1,6 +1,6 @@
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -29,20 +29,6 @@ message(WARNING "-DANDROID_PLATFORM=${ANDROID_PLATFORM_LEVEL}")
 message(WARNING "-DANDROID_ABI=${ANDROID_ABI}")
 message(WARNING "-DANDROID_NATIVE_API_LEVEL=${ANDROID_PLATFORM_LEVEL}")
 
-# Creates and names a library, sets it as either STATIC
-# or SHARED, and provides the relative paths to its source code.
-# You can define multiple libraries, and CMake builds them for you.
-# Gradle automatically packages shared libraries with your APK.
-
-add_library( # Sets the name of the library.
-        pocl_rreferenceandroidjavaclient
-
-        # Sets the library as a shared library.
-        SHARED
-
-        # Provides a relative path to your source file(s).
-        native-lib.cpp)
-
 # Searches for a specified prebuilt library and stores the path as a
 # variable. Because CMake includes system libraries in the search path by
 # default, you only need to specify the name of the public NDK library
@@ -88,6 +74,8 @@ set(BUILD_POCL_ARGS
         -DANDROID_PLATFORM=${ANDROID_PLATFORM_LEVEL}
         -DANDROID_ABI=${ANDROID_ABI}
         -DANDROID_NATIVE_API_LEVEL=${ANDROID_PLATFORM_LEVEL}
+        # to use network discovery
+        -DENABLE_REMOTE_DISCOVERY_ANDROID=YES
         )
 
 ExternalProject_Add(pocl
@@ -97,12 +85,28 @@ ExternalProject_Add(pocl
         BUILD_ALWAYS True
         BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/pocl/lib/libpocl.so
         )
-
+include_directories("${CMAKE_BINARY_DIR}")
 add_library(libpocl SHARED IMPORTED)
 set_target_properties(libpocl PROPERTIES IMPORTED_LOCATION
         ${CMAKE_CURRENT_BINARY_DIR}/pocl/lib/libpocl.so)
 
-add_dependencies(pocl_rreferenceandroidjavaclient pocl)
+# Creates and names a library, sets it as either STATIC
+# or SHARED, and provides the relative paths to its source code.
+# You can define multiple libraries, and CMake builds them for you.
+# Gradle automatically packages shared libraries with your APK.
+
+add_library( # Sets the name of the library.
+        pocl_rreferenceandroidjavaclient
+
+        # Sets the library as a shared library.
+        SHARED
+
+        # Provides a relative path to your source file(s).
+        native-lib.cpp)
+
+target_include_directories(pocl_rreferenceandroidjavaclient
+        PRIVATE
+        ${EXTERNAL_PATH}/pocl/include)
 
 # Specifies libraries CMake should link to your target library. You
 # can link multiple libraries, such as libraries you define in this
@@ -110,9 +114,10 @@ add_dependencies(pocl_rreferenceandroidjavaclient pocl)
 
 target_link_libraries( # Specifies the target library.
         pocl_rreferenceandroidjavaclient
-
-#        ${CMAKE_CURRENT_BINARY_DIR}/pocl/lib/libpocl.so
-        libpocl
         # Links the target library to the log library
         # included in the NDK.
-        ${log-lib})
+        ${log-lib}
+        libpocl
+        )
+
+add_dependencies(pocl_rreferenceandroidjavaclient pocl)

--- a/android/app/src/main/cpp/native-lib.cpp
+++ b/android/app/src/main/cpp/native-lib.cpp
@@ -1,6 +1,7 @@
 #include <jni.h>
 #include <string>
 #include <android/log.h>
+#include "pocl_remote.h"
 
 extern "C"
 JNIEXPORT void JNICALL
@@ -14,4 +15,29 @@ Java_org_portablecl_pocl_1rreferenceandroidjavaclient_NativeUtils_setNativeEnv(J
                         c_value);
 
     setenv(c_key, c_value, 1);
+
+    env->ReleaseStringUTFChars(key, c_key);
+    env->ReleaseStringUTFChars(value, c_value);
+}
+extern "C"
+JNIEXPORT void JNICALL
+Java_org_portablecl_pocl_1rreferenceandroidjavaclient_NativeUtils_remoteAddServer(JNIEnv *env,
+                                                                                  jclass clazz,
+                                                                                  jstring id,
+                                                                                  jstring domain,
+                                                                                  jstring ip_port,
+                                                                                  jstring type,
+                                                                                  jint device_count) {
+
+    char *c_id = (char *) env->GetStringUTFChars(id, 0);
+    char *c_domain = (char *) env->GetStringUTFChars(domain, 0);
+    char *c_ip_port = (char *) env->GetStringUTFChars(ip_port, 0);
+    char *c_type = (char *) env->GetStringUTFChars(type, 0);
+
+    pocl_remote_discovery_add_server(c_id, c_domain, c_ip_port, c_type, (cl_uint)device_count);
+
+    env->ReleaseStringUTFChars(id, c_id);
+    env->ReleaseStringUTFChars(domain, c_domain);
+    env->ReleaseStringUTFChars(ip_port, c_ip_port);
+    env->ReleaseStringUTFChars(type, c_type);
 }

--- a/android/app/src/main/cpp/native-lib.cpp
+++ b/android/app/src/main/cpp/native-lib.cpp
@@ -1,6 +1,10 @@
 #include <jni.h>
 #include <string>
 #include <android/log.h>
+
+#ifndef ENABLE_REMOTE_DISCOVERY_ANDROID
+#define ENABLE_REMOTE_DISCOVERY_ANDROID
+#endif
 #include "pocl_remote.h"
 
 extern "C"

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/ConfigStore.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/ConfigStore.java
@@ -17,6 +17,8 @@ public class ConfigStore {
 
     private final static String devicesKey = "devicestextkey";
 
+    private final static String discoveredIPKey = "discoveredipkey";
+
     /**
      * @param context can be an activity for example
      */
@@ -33,6 +35,13 @@ public class ConfigStore {
 
     public void setRemoteIp(String ipString) {
         editor.putString(keyPrefix+ipKey, ipString);
+    }
+
+    public String getDiscoveredIp() {
+        return preferences.getString(keyPrefix+discoveredIPKey, null);
+    }
+    public void setDiscoveredIp(String dipString) {
+        editor.putString(keyPrefix+discoveredIPKey, dipString);
     }
 
     public String getPoclDevices() {

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DNSDiscoveryHandler.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DNSDiscoveryHandler.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.net.nsd.NsdManager;
 import android.net.nsd.NsdServiceInfo;
-import android.net.wifi.WifiManager;
 import android.util.Log;
 
 /**
@@ -34,7 +33,6 @@ public class DNSDiscoveryHandler {
                 (NsdManager) activity.getApplicationContext().getSystemService(Context.NSD_SERVICE);
         // Assign the RemoteDiscoveryManager instance
         remoteDiscoveryManager = ds;
-        WifiManager wifiManager = (WifiManager) activity.getSystemService(Context.WIFI_SERVICE);
 
         stop(); // Stop any ongoing discovery process, if any
         setupDiscoveryListener(); // Initialize discovery listener

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DNSDiscoveryHandler.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DNSDiscoveryHandler.java
@@ -1,0 +1,122 @@
+package org.portablecl.pocl_rreferenceandroidjavaclient;
+
+import android.app.Activity;
+import android.content.Context;
+import android.net.nsd.NsdManager;
+import android.net.nsd.NsdServiceInfo;
+import android.net.wifi.WifiManager;
+import android.util.Log;
+
+/**
+ * Class that implements necessary methods for utilizing Android's NSD (Network Service Discovery)
+ * service for network discovery using mDNS and DNS-SD protocols.
+ */
+public class DNSDiscoveryHandler {
+    private NsdManager nsdManager; // Manages network service discovery
+    private NsdManager.DiscoveryListener discoveryListener; // Listens for discovery events
+    public static final String MDNS_SERVICE_TYPE = "_pocl._tcp"; // The service type to discover
+    public static final String TAG = "DISC";
+
+    /*
+     * Instance of RemoteDiscoveryManager to manage discovered devices.
+     * This is specific to the current use case and may need modification
+     * if reused for other applications.
+     */
+    RemoteDiscoveryManager remoteDiscoveryManager;
+
+    /**
+     * Initializes the DNS discovery process. Sets up the NSD Manager, stops any existing
+     * discoveries, and starts discovering services.
+     */
+    public void init(RemoteDiscoveryManager ds, Activity activity) {
+        // Obtain NSD service from the application context
+        nsdManager =
+                (NsdManager) activity.getApplicationContext().getSystemService(Context.NSD_SERVICE);
+        // Assign the RemoteDiscoveryManager instance
+        remoteDiscoveryManager = ds;
+        WifiManager wifiManager = (WifiManager) activity.getSystemService(Context.WIFI_SERVICE);
+
+        stop(); // Stop any ongoing discovery process, if any
+        setupDiscoveryListener(); // Initialize discovery listener
+        nsdManager.discoverServices(MDNS_SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener);
+    }
+
+    /**
+     * Stops the current service discovery process.
+     */
+    public void stop() {
+        if (discoveryListener != null) {
+            try {
+                nsdManager.stopServiceDiscovery(discoveryListener);
+                discoveryListener = null;
+                nsdManager = null;
+                remoteDiscoveryManager = null;
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Sets up the DiscoveryListener to handle service discovery events such as
+     * service found, lost, or any discovery failures.
+     */
+    private void setupDiscoveryListener() {
+        discoveryListener = new NsdManager.DiscoveryListener() {
+            @Override
+            public void onStartDiscoveryFailed(String s, int i) {
+                Log.e(TAG, "Discovery failed: Error code: " + i);
+            }
+
+            @Override
+            public void onStopDiscoveryFailed(String s, int i) {
+                Log.e(TAG, "Discovery failed: Error code: " + i);
+            }
+
+            @Override
+            public void onDiscoveryStarted(String s) {
+                Log.d(TAG, "Discovery started:  " + s);
+            }
+
+            @Override
+            public void onDiscoveryStopped(String s) {
+                Log.d(TAG, "Discovery stopped:  " + s);
+            }
+
+            @Override
+            public void onServiceFound(NsdServiceInfo nsdServiceInfo) {
+                Log.d(TAG, "Service found: " + nsdServiceInfo);
+                // Attempt to resolve the service
+                nsdManager.resolveService(nsdServiceInfo, setupResolveListener());
+            }
+
+            @Override
+            public void onServiceLost(NsdServiceInfo nsdServiceInfo) {
+                Log.d(TAG, "Service lost: " + nsdServiceInfo);
+                // Remove the lost service from the spinner
+                remoteDiscoveryManager.removeDeviceFromSpinner(nsdServiceInfo.getServiceName());
+            }
+        };
+    }
+
+    /**
+     * Sets up the ResolveListener to handle events for resolving a discovered service.
+     */
+    private NsdManager.ResolveListener setupResolveListener() {
+        return new NsdManager.ResolveListener() {
+            @Override
+            public void onResolveFailed(NsdServiceInfo nsdServiceInfo, int i) {
+                Log.e(TAG, "Resolve failed: Error code" + i);
+            }
+
+            @Override
+            public void onServiceResolved(NsdServiceInfo nsdServiceInfo) {
+                Log.d(TAG,
+                        "Service resolved: " + nsdServiceInfo.getHost().toString() + ":" + nsdServiceInfo.getPort());
+                // Pass resolved service to the RemoteDiscoveryManager
+                remoteDiscoveryManager.addDiscoveredServer(nsdServiceInfo);
+            }
+        };
+    }
+
+}

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DeviceDemoActivity.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DeviceDemoActivity.java
@@ -14,6 +14,8 @@ import static org.portablecl.pocl_rreferenceandroidjavaclient.NativeUtils.setNat
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.HandlerThread;
 import android.util.Log;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -43,6 +45,15 @@ public class DeviceDemoActivity extends AppCompatActivity {
      */
     TextView tv;
     private ActivityMainBinding binding;
+
+    /**
+     * a thread to run things in background and not block the UI thread
+     */
+    private HandlerThread backgroundThread;
+    /**
+     * a Handler that is used to schedule work on the backgroundThread
+     */
+    private Handler backgroundThreadHandler;
 
     /**
      * Returns the value of the device info parameter with the given name
@@ -90,8 +101,95 @@ public class DeviceDemoActivity extends AppCompatActivity {
      */
     private void logString(String input) {
         Log.w("jocl", input);
-        tv.append(input + "\n");
+        runOnUiThread(() -> tv.append(input + "\n"));
     }
+
+    /**
+     * function to start the backgroundThread + handler
+     */
+    private void startBackgroundThread() {
+
+        backgroundThread = new HandlerThread("MandelbrotBackground");
+        backgroundThread.start();
+        backgroundThreadHandler = new Handler(backgroundThread.getLooper());
+
+    }
+
+    /**
+     * function to safely stop backgroundThread + handler
+     */
+    private void stopBackgroundThread() {
+
+        // interrupt the thread, causing the while loop exit
+        backgroundThread.interrupt();
+        backgroundThread.quitSafely();
+        try {
+            backgroundThread.join(1000);
+            backgroundThread = null;
+            backgroundThreadHandler = null;
+
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private final Runnable platformInfoRunnable = new Runnable() {
+
+
+        @Override
+        public void run() {
+            try {
+                // Obtain the number of platforms
+                int[] numPlatforms = new int[1];
+                clGetPlatformIDs(0, null, numPlatforms);
+
+                String displayString = "";
+                displayString = "Number of platforms: " + numPlatforms[0];
+                logString(displayString);
+
+                // Obtain the platform IDs
+                cl_platform_id[] platforms = new cl_platform_id[numPlatforms[0]];
+                clGetPlatformIDs(platforms.length, platforms, null);
+
+                // Collect all devices of all platforms
+                List<cl_device_id> devices = new ArrayList<cl_device_id>();
+                for (cl_platform_id platform : platforms) {
+                    String platformName = getString(platform, CL_PLATFORM_NAME);
+
+                    // Obtain the number of devices for the current platform
+                    int[] numDevices = new int[1];
+                    clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, null, numDevices);
+
+                    displayString = "Number of devices in platform " + platformName + ": " + numDevices[0];
+                    logString(displayString);
+
+                    cl_device_id[] devicesArray = new cl_device_id[numDevices[0]];
+                    clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, numDevices[0], devicesArray, null);
+
+                    devices.addAll(Arrays.asList(devicesArray));
+                }
+
+                // Print some info on each device
+                for (int i = 0; i < devices.size(); i++) {
+                    cl_device_id device = devices.get(i);
+                    String deviceName = getString(device, CL_DEVICE_NAME);
+                    displayString = String.format("device %d name: %s", i, deviceName);
+                    logString(displayString);
+
+                    String deviceVersion = getString(device, CL_DEVICE_VERSION);
+                    displayString = String.format("device %d version: %s", i, deviceVersion);
+                    logString(displayString);
+
+                    String deviceDriverVersion = getString(device, CL_DRIVER_VERSION);
+                    displayString = String.format("device %d driver version: %s", i, deviceDriverVersion);
+                    logString(displayString);
+                }
+            } catch (OutOfMemoryError | Exception e) {
+                Toast.makeText(DeviceDemoActivity.this, "error occurred, possibly incorrect server address?",
+                        Toast.LENGTH_LONG).show();
+            }
+        }
+    };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -115,56 +213,8 @@ public class DeviceDemoActivity extends AppCompatActivity {
         tv = binding.sampleText;
         tv.setText("");
 
-        try {
-            // Obtain the number of platforms
-            int[] numPlatforms = new int[1];
-            clGetPlatformIDs(0, null, numPlatforms);
-
-            String displayString = "";
-            displayString = "Number of platforms: " + numPlatforms[0];
-            logString(displayString);
-
-            // Obtain the platform IDs
-            cl_platform_id[] platforms = new cl_platform_id[numPlatforms[0]];
-            clGetPlatformIDs(platforms.length, platforms, null);
-
-            // Collect all devices of all platforms
-            List<cl_device_id> devices = new ArrayList<cl_device_id>();
-            for (int i = 0; i < platforms.length; i++) {
-                String platformName = getString(platforms[i], CL_PLATFORM_NAME);
-
-                // Obtain the number of devices for the current platform
-                int[] numDevices = new int[1];
-                clGetDeviceIDs(platforms[i], CL_DEVICE_TYPE_ALL, 0, null, numDevices);
-
-                displayString = "Number of devices in platform " + platformName + ": " + numDevices[0];
-                logString(displayString);
-
-                cl_device_id[] devicesArray = new cl_device_id[numDevices[0]];
-                clGetDeviceIDs(platforms[i], CL_DEVICE_TYPE_ALL, numDevices[0], devicesArray, null);
-
-                devices.addAll(Arrays.asList(devicesArray));
-            }
-
-            // Print some info on each device
-            for (int i = 0; i < devices.size(); i++) {
-                cl_device_id device = devices.get(i);
-                String deviceName = getString(device, CL_DEVICE_NAME);
-                displayString = String.format("device %d name: %s", i, deviceName);
-                logString(displayString);
-
-                String deviceVersion = getString(device, CL_DEVICE_VERSION);
-                displayString = String.format("device %d version: %s", i, deviceVersion);
-                logString(displayString);
-
-                String deviceDriverVersion = getString(device, CL_DRIVER_VERSION);
-                displayString = String.format("device %d driver version: %s", i, deviceDriverVersion);
-                logString(displayString);
-            }
-        }catch (OutOfMemoryError | Exception e) {
-            Toast.makeText( this, "error occurred, possibly incorrect server address?",
-                    Toast.LENGTH_LONG).show();
-        }
+        startBackgroundThread();
+        backgroundThreadHandler.post(platformInfoRunnable);
     }
 
     /**
@@ -174,6 +224,7 @@ public class DeviceDemoActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
 
+        stopBackgroundThread();
         // exit and restart the app after going back to startup activity
         Context appctx = getApplicationContext();
         Intent i = appctx.getPackageManager().getLaunchIntentForPackage(appctx.getPackageName());

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DeviceDemoActivity.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DeviceDemoActivity.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+
 /**
  * inspired by the JOCLSamples devices query
  * (
@@ -41,7 +42,6 @@ public class DeviceDemoActivity extends AppCompatActivity {
      * used to print text on the app screen
      */
     TextView tv;
-
     private ActivityMainBinding binding;
 
     /**
@@ -165,7 +165,6 @@ public class DeviceDemoActivity extends AppCompatActivity {
             Toast.makeText( this, "error occurred, possibly incorrect server address?",
                     Toast.LENGTH_LONG).show();
         }
-
     }
 
     /**

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DeviceDemoActivity.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DeviceDemoActivity.java
@@ -105,7 +105,7 @@ public class DeviceDemoActivity extends AppCompatActivity {
         setNativeEnv("POCL_CACHE_DIR", cache_dir);
         String devicesString = configStore.getPoclDevices();
         setNativeEnv("POCL_DEVICES", devicesString);
-        String remoteString = configStore.getRemoteIp() + "/0";
+        String remoteString = configStore.getRemoteIp();
         setNativeEnv("POCL_REMOTE0_PARAMETERS", remoteString);
         setNativeEnv("POCL_DEBUG", "all");
 

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DiscoverySpinnerAdapter.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DiscoverySpinnerAdapter.java
@@ -16,13 +16,11 @@ import java.util.List;
  */
 public class DiscoverySpinnerAdapter extends ArrayAdapter<RemoteDiscoveryManager.DeviceSelectionEntry> {
 
-    private Context context; // Context in which the adapter is used
     private List<RemoteDiscoveryManager.DeviceSelectionEntry> objects; // List of device entries to be displayed in the spinner
 
     public DiscoverySpinnerAdapter(@NonNull Context context, int resource,
                                    @NonNull List<RemoteDiscoveryManager.DeviceSelectionEntry> objects) {
         super(context, resource, objects);
-        this.context = context;
         this.objects = objects;
     }
 

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DiscoverySpinnerAdapter.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/DiscoverySpinnerAdapter.java
@@ -1,0 +1,64 @@
+package org.portablecl.pocl_rreferenceandroidjavaclient;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import java.util.List;
+
+/**
+ * Custom adapter for a Spinner to display device details from a list of
+ * DeviceSelectionEntry objects in a specific format.
+ */
+public class DiscoverySpinnerAdapter extends ArrayAdapter<RemoteDiscoveryManager.DeviceSelectionEntry> {
+
+    private Context context; // Context in which the adapter is used
+    private List<RemoteDiscoveryManager.DeviceSelectionEntry> objects; // List of device entries to be displayed in the spinner
+
+    public DiscoverySpinnerAdapter(@NonNull Context context, int resource,
+                                   @NonNull List<RemoteDiscoveryManager.DeviceSelectionEntry> objects) {
+        super(context, resource, objects);
+        this.context = context;
+        this.objects = objects;
+    }
+
+    /**
+     * Provides the view for the selected item displayed in the spinner.
+     */
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        TextView label = (TextView) super.getView(position, convertView, parent);
+        if (position == 0) {
+            label.setText(objects.get(position).getDeviceAddress());
+            return label;
+        }
+        label.setText(objects.get(position).getDescription());
+
+        return label;
+    }
+
+    /**
+     * Provides the view for each item in the dropdown list of the spinner.
+     */
+    @Override
+    public View getDropDownView(int position, View convertView, ViewGroup parent) {
+        TextView label = (TextView) super.getDropDownView(position, convertView, parent);
+        for (RemoteDiscoveryManager.DeviceSelectionEntry s : objects) {
+            if(s.deviceAddress.equals(RemoteDiscoveryManager.DEFAULT_SPINNER_LABEL)) {
+                continue;
+            }
+        }
+        if (position == 0) {
+            label.setText(objects.get(position).getDeviceAddress());
+            return label;
+        }
+        label.setText(objects.get(position).getDescription());
+
+        return label;
+    }
+
+}

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/NativeUtils.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/NativeUtils.java
@@ -14,8 +14,20 @@ public class NativeUtils {
      * see http://portablecl.org/docs/html/using.html#tuning-pocl-behavior-with-env-variables
      * for a list of options
      *
-     * @param key / name of the variable
+     * @param key   / name of the variable
      * @param value the value to set the variable to
      */
     public static native void setNativeEnv(String key, String value);
+
+    /**
+     * Dynamically add discovered server and its devices to the PoCL runtime through the remote
+     * driver.
+     *
+     * @param id Unique ID with which server advertises itself.
+     * @param domain Domain name in which the server was found.
+     * @param IpPort Combination of "IP:port"
+     * @param type Type of the discovered service. Eg type: "_pocl._tcp"
+     * @param deviceCount Number of devices in the remote server.
+     */
+    public static native void remoteAddServer(String id, String domain, String IpPort, String type, int deviceCount);
 }

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/RemoteDiscoveryManager.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/RemoteDiscoveryManager.java
@@ -1,0 +1,261 @@
+package org.portablecl.pocl_rreferenceandroidjavaclient;
+
+import android.app.Activity;
+import android.net.nsd.NsdServiceInfo;
+import android.util.Log;
+import android.widget.AdapterView;
+import android.widget.Spinner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * This class handles the discovery of remote devices and manages the spinner for choosing available
+ * devices. It implements necessary sub-classes for server information and device selection entries,
+ * and includes methods for adding/removing discovered devices.
+ */
+public class RemoteDiscoveryManager {
+
+    // Information about a discovered server
+    public class ServerInfo {
+        String serverID;
+        String serverIP;
+        String serverInfo;
+        int deviceCount;
+    }
+
+    // Represents a device in the spinner, with an address and type.
+    public class DeviceSelectionEntry {
+        public String deviceAddress;
+        public String deviceType;
+
+        // Default constructor with a placeholder value.
+        public DeviceSelectionEntry() {
+            this.deviceAddress = DEFAULT_SPINNER_LABEL;
+        }
+
+        // Constructor with address and device type.
+        public DeviceSelectionEntry(String address, String device_type) {
+            this.deviceAddress = address;
+            this.deviceType = device_type;
+        }
+
+        // Returns string description of the device.
+        public String getDescription() {
+            return (deviceType + " | " + deviceAddress);
+        }
+
+        // Returns device address.
+        public String getDeviceAddress() {
+            return (deviceAddress);
+        }
+    }
+
+    private final Activity currentActivity;
+    public static final String TAG = "DISC";
+    public static final String DEFAULT_SPINNER_LABEL = "Select a remote device";
+    private final DiscoverySpinnerAdapter deviceSpinnerAdapter;
+    public ArrayList<DeviceSelectionEntry> deviceList;
+    private final Spinner deviceSpinner;
+    public static HashMap<String, ServerInfo> discoveredServers;
+    private static DNSDiscoveryHandler dnsDiscoveryHandler;
+
+    // Constructor to initialize the RemoteDiscoveryManager with the given activity, spinner, and
+    // listener.
+    public RemoteDiscoveryManager(Activity activity, Spinner discoverySpinner, AdapterView.OnItemSelectedListener listener) {
+        this.currentActivity = activity;
+        if (discoveredServers == null) {
+            initializeServerMap();
+        }
+
+        // Initialize device list and spinner adapter
+        deviceList = new ArrayList<>();
+        deviceList.add(new DeviceSelectionEntry());
+        deviceSpinnerAdapter = new DiscoverySpinnerAdapter(activity, android.R.layout.simple_spinner_item, deviceList);
+        deviceSpinner = discoverySpinner;
+        discoverySpinner.setAdapter(deviceSpinnerAdapter);
+        discoverySpinner.setOnItemSelectedListener(listener);
+
+        // Initialize DNS discovery handler
+        dnsDiscoveryHandler = new DNSDiscoveryHandler();
+        dnsDiscoveryHandler.init(this, activity);
+    }
+
+    // Stops all discovery processes and clears server map.
+    public void stopAllDiscoveries() {
+        dnsDiscoveryHandler.stop();
+        clearServerMap();
+    }
+
+    // Initializes the hashmap for discovered servers.
+    private void initializeServerMap() {
+        clearServerMap();
+        discoveredServers = new HashMap<>();
+    }
+
+    // Clears the server map to release resources.
+    private void clearServerMap() {
+        if (discoveredServers != null) {
+            discoveredServers.clear();
+            discoveredServers = null;
+        }
+    }
+
+    /**
+     * Adds a newly discovered server to the list, updating the server map. This function is called
+     * by DNSDiscoveryhandler with the argument of type NsdServiceInfo.
+     */
+    public void addDiscoveredServer(NsdServiceInfo serviceInfo) {
+        String key = serviceInfo.getHost().toString().substring(1) + ":" + serviceInfo.getPort();
+        String sName = serviceInfo.getServiceName();
+        // NSD discovery adds '{' before the txt sent from the server and adds '=null}' after the
+        // txt. These have to be accounted for when using the txt field.
+        String txt = serviceInfo.getAttributes().toString();
+        int devices = txt.length() - 7; // Adjust the txt string to remove unwanted characters
+        txt = txt.substring(1, devices + 1);
+        updateServerMap(key, sName, txt, devices);
+    }
+
+    /**
+     * Updates the server map with the provided information, adding or updating servers.
+     */
+    private void updateServerMap(String key, String sID, String txt, int deviceNum) {
+        // logic to decide if a discovered server is new or old, if server already exists, update it
+        if (discoveredServers.containsKey(key)) {
+            if (discoveredServers.get(key).serverID.equals(sID)) {
+                Log.d(TAG, "(RESOLVER) Service " + sID + " is known with same session.");
+                addDevicesToSpinner(key, txt, deviceNum);
+            } else {
+                Log.d(TAG, "(RESOLVER) Service " + sID + " is known but old session has " + "expired" + ".");
+                discoveredServers.get(key).serverID = sID;
+                discoveredServers.get(key).serverIP = key;
+                discoveredServers.get(key).serverInfo = txt;
+                discoveredServers.get(key).deviceCount = deviceNum;
+                addDevicesToSpinner(key, txt, deviceNum);
+            }
+        } else {
+            String _key = null;
+            for (Map.Entry<String, ServerInfo> entry : discoveredServers.entrySet()) {
+                if (entry.getValue().serverID.equals(sID)) {
+                    _key = entry.getKey();
+                }
+            }
+            if (_key != null) {
+                Log.d(TAG, "(RESOLVER) Service " + sID + " is registered with a different " + "address.");
+            } else {
+                // If server is new, add it to the map
+                ServerInfo found = new ServerInfo();
+                found.serverID = sID;
+                found.serverIP = key;
+                found.serverInfo = txt;
+                found.deviceCount = deviceNum;
+                discoveredServers.put(key, found);
+                Log.d(TAG, "(RESOLVER) Service " + sID + "is being added.\n");
+                addDevicesToSpinner(key, txt, deviceNum);
+            }
+        }
+    }
+
+    /**
+     * Adds the devices corresponding to the discovered server into the spinner.
+     */
+    public void addDevicesToSpinner(String key, String txt, int deviceNum) {
+        for (int i = 0; i < deviceNum; i++) {
+            // 0:CL_DEVICE_TYPE_CPU , 1:CL_DEVICE_TYPE_GPU , 2:CL_DEVICE_TYPE_ACCELERATOR ,
+            // 4:CL_DEVICE_TYPE_CUSTOM
+            String deviceType;
+            switch (txt.charAt(i)) {
+                case '0':
+                    deviceType = "CPU";
+                    break;
+                case '1':
+                    deviceType = "GPU";
+                    break;
+                case '2':
+                    deviceType = "Accelerator";
+                    break;
+                case '4':
+                    deviceType = "Custom";
+                    break;
+                default:
+                    deviceType = "NA";
+            }
+
+            DeviceSelectionEntry so = new DeviceSelectionEntry(key + "/" + String.valueOf(i), deviceType);
+            boolean contains = false;
+
+            // Check if the device is already in the list
+            for (DeviceSelectionEntry value : deviceList) {
+                if (value.deviceAddress.contains(so.deviceAddress)) {
+                    contains = true;
+                    break;
+                }
+            }
+
+            boolean finalContains = contains;
+            currentActivity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    // If the device is not already in the list, add it
+                    if (!finalContains) {
+                        deviceList.add(so);
+                        deviceSpinnerAdapter.notifyDataSetChanged();
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Removes the devices from the spinner for a given server.
+     */
+    public void removeDeviceFromSpinner(String serverID) {
+        String key = null;
+        int deviceNum = 0;
+
+        // Find the corresponding server info using the discovered serverID
+        for (Map.Entry<String, ServerInfo> entry : discoveredServers.entrySet()) {
+            if (Objects.equals(serverID, entry.getValue().serverID)) {
+                try {
+                    key = entry.getKey();
+                    deviceNum = entry.getValue().deviceCount;
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                break;
+            }
+        }
+
+        // If no matching server found then return
+        if (key == null) {
+            Log.w(TAG, "Key is null. Spinner entry " + serverID + " previously removed.");
+            return;
+        }
+
+        // If no devices then return
+        if (deviceNum == 0) {
+            Log.w(TAG, "Number of devices is 0. Nothing to remove from the spinner");
+            return;
+        }
+
+        // Remove devices from spinner
+        for (int i = 0; i < deviceNum; i++) {
+            String finalKey = key + "/" + String.valueOf(i);
+            currentActivity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    for (DeviceSelectionEntry value : deviceList) {
+                        if (value.deviceAddress.contains(finalKey)) {
+                            deviceList.remove(value);
+                            deviceSpinnerAdapter.notifyDataSetChanged();
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+}

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/StartupActivity.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/StartupActivity.java
@@ -76,7 +76,7 @@ public class StartupActivity extends AppCompatActivity {
         remoteSwitch.setClickable(false);
 
         remoteText = findViewById(R.id.remoteText);
-        remoteText.setText("");
+        remoteText.setText(configStore.getRemoteIp());
         discoveredRemoteIP = configStore.getDiscoveredIp();
 
         demoButton1 = findViewById(R.id.demoButton1);

--- a/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/StartupActivity.java
+++ b/android/app/src/main/java/org/portablecl/pocl_rreferenceandroidjavaclient/StartupActivity.java
@@ -1,24 +1,22 @@
 package org.portablecl.pocl_rreferenceandroidjavaclient;
 
-import static java.lang.Character.isDigit;
-
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-
-import com.google.android.material.appbar.CollapsingToolbarLayout;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.google.android.material.snackbar.Snackbar;
+import android.util.Log;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.Button;
+import android.widget.Spinner;
+import android.widget.Switch;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
-import android.util.Log;
-import android.view.View;
-import android.widget.Button;
-import android.widget.Switch;
-import android.widget.TextView;
-import android.widget.Toast;
+import com.google.android.material.appbar.CollapsingToolbarLayout;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import org.portablecl.pocl_rreferenceandroidjavaclient.databinding.ActivityStartupBinding;
 
@@ -32,11 +30,15 @@ public class StartupActivity extends AppCompatActivity {
 
     private TextView remoteText;
 
+    private String discoveredRemoteIP;
+
     private Button demoButton1;
 
     private Button demoButton2;
 
     private ConfigStore configStore;
+
+    RemoteDiscoveryManager remoteDiscoveryManager;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -65,7 +67,7 @@ public class StartupActivity extends AppCompatActivity {
         configStore = new ConfigStore(this);
         String poclDevicesString = configStore.getPoclDevices();
         proxySwitch = findViewById(R.id.proxySwitch);
-        if(poclDevicesString.contains("proxy")) {
+        if (poclDevicesString.contains("proxy")) {
             proxySwitch.setChecked(true);
         }
         remoteSwitch = findViewById(R.id.remoteSwitch);
@@ -74,13 +76,37 @@ public class StartupActivity extends AppCompatActivity {
         remoteSwitch.setClickable(false);
 
         remoteText = findViewById(R.id.remoteText);
-        String remoteIp = configStore.getRemoteIp();
-        remoteText.setText(remoteIp);
+        remoteText.setText("");
+        discoveredRemoteIP = configStore.getDiscoveredIp();
 
         demoButton1 = findViewById(R.id.demoButton1);
         demoButton1.setOnClickListener(demoButtonListener);
         demoButton2 = findViewById(R.id.demoButton2);
         demoButton2.setOnClickListener(demoButtonListener);
+
+        Spinner discoverySpinner = findViewById(R.id.discoverySpinner);
+        // Set up a listener for the discovery spinner to handle user selection of a discovered device.
+        remoteDiscoveryManager = new RemoteDiscoveryManager(this, discoverySpinner,
+                new AdapterView.OnItemSelectedListener() {
+                    @Override
+                    public void onItemSelected(AdapterView<?> parent, View view, int position,
+                                               long id) {
+
+                        String selectedServer = remoteDiscoveryManager.deviceList.get(position).getDeviceAddress();
+                        if (!selectedServer.equals(RemoteDiscoveryManager.DEFAULT_SPINNER_LABEL)) {
+                            Log.d("DISC", "Spinner position selected: " + position + " : server " +
+                                    "selected " +
+                                    ": " + selectedServer);
+                            remoteText.setText(selectedServer);
+                            discoveredRemoteIP = selectedServer;
+                        }
+                    }
+
+                    @Override
+                    public void onNothingSelected(AdapterView<?> parent) {
+                    }
+                });
+
     }
 
     /**
@@ -92,13 +118,13 @@ public class StartupActivity extends AppCompatActivity {
         public void onClick(View v) {
 
             String poclDevices = "";
-            if(proxySwitch.isChecked()) {
-                poclDevices +="proxy ";
+            if (proxySwitch.isChecked()) {
+                poclDevices += "proxy ";
             }
-            if(remoteSwitch.isChecked()) {
-                poclDevices +="remote ";
+            if (remoteSwitch.isChecked()) {
+                poclDevices += "remote ";
             }
-            if(poclDevices.isEmpty()) {
+            if (poclDevices.isEmpty()) {
                 Toast.makeText(StartupActivity.this, "Please select a device first",
                         Toast.LENGTH_SHORT).show();
                 return;
@@ -107,16 +133,29 @@ public class StartupActivity extends AppCompatActivity {
             // todo add some ip string checking
             configStore.setRemoteIp(remoteText.getText().toString());
             configStore.setPoclDevices(poclDevices);
+            configStore.setDiscoveredIp(discoveredRemoteIP);
             configStore.saveConfig();
 
             Class demoClass;
-            if(v == demoButton1) {
+            if (v == demoButton1) {
                 demoClass = DeviceDemoActivity.class;
-            }else {
+            } else {
                 demoClass = MandelbrotDemoActivity.class;
             }
             Intent i = new Intent(getApplicationContext(), demoClass);
             startActivity(i);
         }
     };
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        remoteDiscoveryManager.stopAllDiscoveries();
+    }
+
+    @Override
+    protected void onDestroy() {
+        remoteDiscoveryManager.stopAllDiscoveries();
+        super.onDestroy();
+    }
 }

--- a/android/app/src/main/res/layout/activity_mendelbrot_demo.xml
+++ b/android/app/src/main/res/layout/activity_mendelbrot_demo.xml
@@ -6,6 +6,20 @@
     android:layout_height="match_parent"
     tools:context=".MandelbrotDemoActivity">
 
+    <Spinner
+        android:id="@+id/discoverySpinner2"
+        android:layout_width="355dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="28dp"
+        android:layout_marginTop="50dp"
+        android:layout_marginEnd="28dp"
+        android:background="@android:drawable/btn_dropdown"
+        android:popupBackground="@color/purple_200"
+        android:spinnerMode="dropdown"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <SurfaceView
         android:id="@+id/MandelbrotView"
         android:layout_width="wrap_content"

--- a/android/app/src/main/res/layout/content_scrolling.xml
+++ b/android/app/src/main/res/layout/content_scrolling.xml
@@ -14,52 +14,92 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/textView3"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="PoCL Device"
-            android:textAlignment="center"
-            android:textSize="20sp" />
-
-        <TableRow
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <Switch
-                android:id="@+id/proxySwitch"
-                android:layout_width="100dp"
+            <Spinner
+                android:id="@+id/discoverySpinner"
+                android:layout_width="355dp"
+                android:layout_height="48dp"
+                android:layout_marginStart="28dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="28dp"
+                android:background="@android:drawable/btn_dropdown"
+                android:popupBackground="@color/purple_200"
+                android:spinnerMode="dropdown"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/textView3" />
+
+            <TextView
+                android:id="@+id/textView3"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Local (proxy)" />
+                android:layout_marginTop="16dp"
+                android:text="PoCL Device"
+                android:textAlignment="center"
+                android:textSize="20sp"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:layout_editor_absoluteX="0dp" />
 
             <Switch
                 android:id="@+id/remoteSwitch"
-                android:layout_width="100dp"
-                android:layout_height="wrap_content"
+                android:layout_width="175dp"
+                android:layout_height="38dp"
+                android:layout_marginTop="40dp"
+                android:layout_marginEnd="17dp"
                 android:layout_weight="1"
-                android:text="Remote (PoCL-R)" />
-        </TableRow>
+                android:text="Remote (PoCL-R)"
+                android:textAlignment="textEnd"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/discoverySpinner" />
 
-        <EditText
-            android:id="@+id/remoteText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:inputType="text"
-            android:text="Remote IP address" />
+            <Switch
+                android:id="@+id/proxySwitch"
+                android:layout_width="150dp"
+                android:layout_height="38dp"
+                android:layout_marginStart="12dp"
+                android:layout_marginTop="40dp"
+                android:layout_weight="1"
+                android:text="Local (proxy)"
+                android:textAlignment="textEnd"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/discoverySpinner" />
 
-        <Button
-            android:id="@+id/demoButton1"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Start device info demo" />
+            <EditText
+                android:id="@+id/remoteText"
+                android:layout_width="280dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="30dp"
+                android:layout_marginTop="185dp"
+                android:layout_marginEnd="30dp"
+                android:ems="10"
+                android:inputType="text"
+                android:text="Remote IP address"
+                android:textAlignment="center"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/textView3" />
 
-        <Button
-            android:id="@+id/demoButton2"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Start mendelbrot demo" />
+            <Button
+                android:id="@+id/demoButton1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:text="Start device info demo"
+                app:layout_constraintTop_toBottomOf="@+id/remoteText"
+                tools:layout_editor_absoluteX="0dp" />
+
+            <Button
+                android:id="@+id/demoButton2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="Start mendelbrot demo"
+                app:layout_constraintTop_toBottomOf="@+id/demoButton1"
+                tools:layout_editor_absoluteX="0dp" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
This PR adds the remote discovery feature to the reference app.

- Network discovery is performed through mDNS / DNS-SD using Android's NSD library.
- Spinner displaying discovered devices added to the startup and MandelbrotDemo activities.
- Dynamic addition of server and its devices performed using `pocl_remote_discovery_add_server()` function, see [PR](https://github.com/pocl/pocl/pull/1702).

This PR is to merged after the [Android: remote device addition](https://github.com/pocl/pocl/pull/1702) is merged to PoCL main. 